### PR TITLE
fixes #15 - Input text field gets cleared after message is sent

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,7 @@ text.onkeypress = function(e){
   var keyCode = e.keyCode || e.which;
   if (keyCode == '13'){
     let message = text.value;
+    text.value = "";
     send_message(message);
     append(message, { name: "class", val: "from-me" });
     addReply();


### PR DESCRIPTION
The input text field automatically gets cleared once the message
is sent.