### PR TITLE
fixes #20 - Implemented copy context menu-item

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 const electron = require('electron');
 const app = electron.app;
 
+require('electron-context-menu')({
+    prepend: (params, browserWindow) => [{
+        visible: params.mediaType === 'text'
+    }],
+    showInspectElement: false
+});
 
 const BrowserWindow = electron.BrowserWindow;
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "homepage": "http://asksusi.com",
   "devDependencies": {
     "electron": "^1.4.13"
+  },
+  "dependencies": {
+    "electron-context-menu": "^0.8.0"
   }
 }


### PR DESCRIPTION
Implemented a right-click copy context menu-item using electron-context-menu
module
module source link : https://github.com/sindresorhus/electron-context-menu#showinspectelement