### PR TITLE
Fix #83 - Removed white space around background

### DIFF
--- a/app/renderer/css/main.css
+++ b/app/renderer/css/main.css
@@ -1,3 +1,7 @@
+body {
+	overflow: hidden;
+}
+
 #loading {
 	position: fixed;
 	left: 0px;
@@ -6,6 +10,13 @@
 	height: 100%;
 	z-index: 9999;
 	background: url(../../resources/loading.gif) center no-repeat #fff;
+}
+
+#wrapper {
+	height: 102%;
+	width: 102%;
+	margin-left: -8px;
+	margin-top: -8px;
 }
 
 /* CSS for the webview element */


### PR DESCRIPTION
Fixes issue #82, removed white space around webview. The top bar
now takes the entire width of the app.

#### By submitting this pull request I confirm I've read and complied with the below declarations.
- [x] I have tested the changes locally and they are functional.
- [ ] I ensure that I sent this pull request after being assigned to the corresponding issue.
- [x] This pull request has a descriptive title. For example, `Added/Fixed {Feature/Bug}`, not `Update README.md` or `Added new code`.
- [x] This pull request will be closed if I fail to update it even once in a continuous time span of 7 days.